### PR TITLE
Added ability to match on any of the given timestamps

### DIFF
--- a/timespan.py
+++ b/timespan.py
@@ -162,7 +162,7 @@ r"""
 
 """
 
-from datetime import datetime
+from datetime import datetime, time
 
 
 __version__ = '0.1'
@@ -225,7 +225,9 @@ def _span(val, f):
 
 
 def _inside(x, lo, hi):
-    if hi >= lo:
+    if hi == time(0):
+        return lo <= x
+    elif hi >= lo:
         return lo <= x <= hi
     else:
         return x >= lo or x <= hi


### PR DESCRIPTION
Comes in handy in various use cases where it's easy to describe the timestamps with positive statements.
For example: Reception hours could be ['9:00-12:00|mon-fri','13:00-17:00|tue-thu']
I guess you could describe it with a single positive statement and then multiple (in this case 4) negative statements, but this way it's more convenient.

The second commit changes the behavior from:
    >>> timespan.match('17:00-00:00|mon-fri|_|_', datetime(2012,12,23,0)) # Sunday
    True
to:
    >>> timespan.match('17:00-00:00|mon-fri|_|_', datetime(2012,12,23,0)) # Sunday
    False
It is true that it also makes the 00:00 end time corner case exclusive instead of inclusive, but I rather have this than having the match return true at 00:00 between Saturday and Sunday.
Perhaps we can add to the timespan syntax optional inclusive\exclusive markings... perhaps in a future commit...
